### PR TITLE
Libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,27 @@
+BZIP2                 := bzip2
+BZIP2_VERSION         := $(BZIP2)-1.0.6
+BZIP2_SRC             := $(BZIP2_VERSION).tar.gz
+BZIP2_DOWNLOAD        := "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
+
 FREETYPE              := freetype
 FREETYPE_VERSION      := $(FREETYPE)-2.6.2
 FREETYPE_SRC          := $(FREETYPE_VERSION).tar.bz2
 FREETYPE_DOWNLOAD     := http://download.savannah.gnu.org/releases/freetype/freetype-2.6.2.tar.bz2
 
+GIFLIB                := giflib
+GIFLIB_VERSION        := $(GIFLIB)-5.1.1
+GIFLIB_SRC            := $(GIFLIB_VERSION).tar.bz2
+GIFLIB_DOWNLOAD       := "http://sourceforge.net/projects/giflib/files/giflib-5.1.1.tar.bz2"
+
 JANSSON               := jansson
 JANSSON_VERSION       := $(JANSSON)-2.7
 JANSSON_SRC           := $(JANSSON_VERSION).tar.gz
 JANSSON_DOWNLOAD      := https://github.com/akheron/jansson/archive/v2.7.tar.gz
+
+LIBCONFIG             := libconfig
+LIBCONFIG_VERSION     := $(LIBCONFIG)-1.5
+LIBCONFIG_SRC         := $(LIBCONFIG_VERSION).tar.gz
+LIBCONFIG_DOWNLOAD    := "http://www.hyperrealm.com/libconfig/libconfig-1.5.tar.gz"
 
 LIBEXIF               := libexif
 LIBEXIF_VERSION       := $(LIBEXIF)-0.6.21
@@ -18,15 +33,35 @@ LIBJPEGTURBO_VERSION  := $(LIBJPEGTURBO)-1.4.2
 LIBJPEGTURBO_SRC      := $(LIBJPEGTURBO_VERSION).tar.gz
 LIBJPEGTURBO_DOWNLOAD := http://sourceforge.net/projects/libjpeg-turbo/files/1.4.2/libjpeg-turbo-1.4.2.tar.gz/download
 
+LIBMAD                := libmad
+LIBMAD_VERSION        := $(LIBMAD)-0.15.1b
+LIBMAD_SRC            := $(LIBMAD_VERSION).tar.gz
+LIBMAD_DOWNLOAD       := "http://sourceforge.net/projects/mad/files/libmad/0.15.1b/libmad-0.15.1b.tar.gz"
+
+LIBOGG                := libogg
+LIBOGG_VERSION        := $(LIBOGG)-1.3.2
+LIBOGG_SRC            := $(LIBOGG_VERSION).tar.xz
+LIBOGG_DOWNLOAD       := "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz"
+
 LIBPNG                := libpng
 LIBPNG_VERSION        := $(LIBPNG)-1.6.21
 LIBPNG_SRC            := $(LIBPNG_VERSION).tar.xz
 LIBPNG_DOWNLOAD       := http://prdownloads.sourceforge.net/libpng/libpng-1.6.21.tar.xz?download
 
+LIBXML2               := libxml2
+LIBXML2_VERSION       := $(LIBXML2)-2.9.3
+LIBXML2_SRC           := $(LIBXML2_VERSION).tar.gz
+LIBXML2_DOWNLOAD      := "http://xmlsoft.org/sources/libxml2-2.9.3.tar.gz"
+
 LIBXMP_LITE           := libxmp-lite
 LIBXMP_LITE_VERSION   := $(LIBXMP_LITE)-4.3.10
 LIBXMP_LITE_SRC       := $(LIBXMP_LITE_VERSION).tar.gz
 LIBXMP_LITE_DOWNLOAD  := http://sourceforge.net/projects/xmp/files/libxmp/4.3.10/libxmp-lite-4.3.10.tar.gz/download
+
+MBED                  := mbedtls
+MBED_VERSION          := $(MBED)-2.2.1
+MBED_SRC              := $(MBED_VERSION).tgz
+MBED_DOWNLOAD         := "https://tls.mbed.org/download/mbedtls-2.2.1-gpl.tgz"
 
 SQLITE                := sqlite
 SQLITE_VERSION        := $(SQLITE)-autoconf-3100200
@@ -37,6 +72,16 @@ TINYXML               := tinyxml2
 TINYXML_VERSION       := $(TINYXML)-3.0.0
 TINYXML_SRC           := $(TINYXML_VERSION).tar.gz
 TINYXML_DOWNLOAD      := https://github.com/leethomason/tinyxml2/archive/3.0.0.tar.gz
+
+TREMOR                := tremor
+TREMOR_VERSION        := $(TREMOR)-2a1a8f6
+TREMOR_SRC            := $(TREMOR_VERSION).tar.gz
+TREMOR_DOWNLOAD       := https://git.xiph.org/?p=tremor.git;a=snapshot;h=2a1a8f621e500fdf0749f115e2206f82919560a3;sf=tgz
+
+XZ                    := xz
+XZ_VERSION            := $(XZ)-5.2.2
+XZ_SRC                := $(XZ_VERSION).tar.xz
+XZ_DOWNLOAD           := "http://tukaani.org/xz/xz-5.2.2.tar.xz"
 
 ZLIB                  := zlib
 ZLIB_VERSION          := $(ZLIB)-1.2.8
@@ -52,37 +97,64 @@ export CPPFLAGS       := -I$(PORTLIBS_PATH)/armv6k/include
 export LDFLAGS        := -L$(PORTLIBS_PATH)/armv6k/lib
 
 .PHONY: all install install-zlib clean download \
+        $(BZIP2) \
         $(FREETYPE) \
+        $(GIFLIB) \
         $(JANSSON) \
+        $(LIBCONFIG) \
         $(LIBEXIF) \
         $(LIBJPEGTURBO) \
+        $(LIBMAD) \
+        $(LIBOGG) \
         $(LIBPNG) \
+        $(MBED) \
+        $(LIBXML2) \
         $(LIBXMP_LITE) \
         $(SQLITE) \
         $(TINYXML) \
+        $(TREMOR) \
+        $(XZ) \
         $(ZLIB)
 
 all:
 	@echo "Please choose one of the following targets:"
+	@echo "  $(BZIP2)"
 	@echo "  $(FREETYPE) (requires zlib to be installed)"
+	@echo "  $(GIFLIB)"
 	@echo "  $(JANSSON)"
+	@echo "  $(LIBCONFIG)"
 	@echo "  $(LIBEXIF)"
 	@echo "  $(LIBJPEGTURBO)"
+	@echo "  $(LIBMAD)"
+	@echo "  $(LIBOGG)"
 	@echo "  $(LIBPNG) (requires zlib to be installed)"
+	@echo "  $(LIBXML2)"
 	@echo "  $(LIBXMP_LITE)"
+	@echo "  $(MBED) (requires zlib to be installed)"
 	@echo "  $(SQLITE)"
 	@echo "  $(TINYXML)"
+	@echo "  $(TREMOR) (requires $(LIBOGG) to be installed)"
+	@echo "  $(XZ)"
 	@echo "  $(ZLIB)"
 
-download: $(FREETYPE_SRC) $(JANSSON_SRC) $(LIBEXIF_SRC) $(LIBJPEGTURBO_SRC) $(LIBPNG_SRC) $(LIBXMP_LITE_SRC) $(SQLITE_SRC) $(TINYXML_SRC) $(ZLIB_SRC)
+download: $(BZIP2_SRC) $(FREETYPE_SRC) $(GIFLIB_SRC) $(JANSSON_SRC) $(LIBCONFIG_SRC) $(LIBEXIF_SRC) $(LIBJPEGTURBO_SRC) $(LIBMAD_SRC) $(LIBOGG_SRC) $(LIBPNG_SRC) $(LIBXML2_SRC) $(LIBXMP_LITE_SRC) $(MBED_SRC) $(SQLITE_SRC) $(TINYXML_SRC) $(TREMOR_SRC) $(XZ_SRC) $(ZLIB_SRC)
 
-DOWNLOAD = wget -O "$(1)" "$(2)" || curl -o "$(1)" "$(2)"
+DOWNLOAD = wget -O "$(1)" "$(2)" || curl -Lo "$(1)" "$(2)"
+
+$(BZIP2_SRC):
+	@$(call DOWNLOAD,$@,$(BZIP2_DOWNLOAD))
 
 $(FREETYPE_SRC):
 	$(call DOWNLOAD,$@,$(FREETYPE_DOWNLOAD))
 
+$(GIFLIB_SRC):
+	$(call DOWNLOAD,$@,$(GIFLIB_DOWNLOAD))
+
 $(JANSSON_SRC):
 	@$(call DOWNLOAD,$@,$(JANSSON_DOWNLOAD))
+
+$(LIBCONFIG_SRC):
+	@$(call DOWNLOAD,$@,$(LIBCONFIG_DOWNLOAD))
 
 $(LIBEXIF_SRC):
 	@$(call DOWNLOAD,$@,$(LIBEXIF_DOWNLOAD))
@@ -90,11 +162,23 @@ $(LIBEXIF_SRC):
 $(LIBJPEGTURBO_SRC):
 	@$(call DOWNLOAD,$@,$(LIBJPEGTURBO_DOWNLOAD))
 
+$(LIBMAD_SRC):
+	@$(call DOWNLOAD,$@,$(LIBMAD_DOWNLOAD))
+
+$(LIBOGG_SRC):
+	@$(call DOWNLOAD,$@,$(LIBOGG_DOWNLOAD))
+
 $(LIBPNG_SRC):
 	@$(call DOWNLOAD,$@,$(LIBPNG_DOWNLOAD))
 
+$(LIBXML2_SRC):
+	@$(call DOWNLOAD,$@,$(LIBXML2_DOWNLOAD))
+
 $(LIBXMP_LITE_SRC):
 	@$(call DOWNLOAD,$@,$(LIBXMP_LITE_DOWNLOAD))
+
+$(MBED_SRC):
+	@$(call DOWNLOAD,$@,$(MBED_DOWNLOAD))
 
 $(SQLITE_SRC):
 	@$(call DOWNLOAD,$@,$(SQLITE_DOWNLOAD))
@@ -102,8 +186,19 @@ $(SQLITE_SRC):
 $(TINYXML_SRC):
 	@$(call DOWNLOAD,$@,$(TINYXML_DOWNLOAD))
 
+$(TREMOR_SRC):
+	@$(call DOWNLOAD,$@,$(TREMOR_DOWNLOAD))
+
+$(XZ_SRC):
+	@$(call DOWNLOAD,$@,$(XZ_DOWNLOAD))
+
 $(ZLIB_SRC):
 	@$(call DOWNLOAD,$@,$(ZLIB_DOWNLOAD))
+
+$(BZIP2): $(BZIP2_SRC)
+	@[ -d $(BZIP2_VERSION) ] || tar -xzf $<
+	@cd $(BZIP2_VERSION)
+	@$(MAKE) -C $(BZIP2_VERSION) CC=arm-none-eabi-gcc AR=arm-none-eabi-ar RANLIB=arm-none-eabi-ranlib CPPFLAGS="$(CPPFLAGS)" CFLAGS="-D_FILE_OFFSET_BITS=64 -Winline $(CFLAGS)" libbz2.a
 
 $(FREETYPE): $(FREETYPE_SRC)
 	@[ -d $(FREETYPE_VERSION) ] || tar -xjf $<
@@ -111,12 +206,24 @@ $(FREETYPE): $(FREETYPE_SRC)
 	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static --without-harfbuzz
 	@$(MAKE) -C $(FREETYPE_VERSION)
 
+$(GIFLIB): $(GIFLIB_SRC)
+	@[ -d $(GIFLIB_VERSION) ] || tar -xjf $<
+	@cd $(GIFLIB_VERSION) && \
+	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
+	@$(MAKE) -C $(GIFLIB_VERSION)
+
 $(JANSSON): $(JANSSON_SRC)
 	@[ -d $(JANSSON_VERSION) ] || tar -xzf $<
 	@cd $(JANSSON_VERSION) && \
 	 autoreconf -i && \
 	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
 	@$(MAKE) -C $(JANSSON_VERSION)
+
+$(LIBCONFIG): $(LIBCONFIG_SRC)
+	@[ -d $(LIBCONFIG_VERSION) ] || tar -xzf $<
+	@cd $(LIBCONFIG_VERSION) && \
+	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-cxx --disable-examples
+	@$(MAKE) -C $(LIBCONFIG_VERSION)/lib
 
 $(LIBEXIF): $(LIBEXIF_SRC)
 	@[ -d $(LIBEXIF_VERSION) ] || tar -xjf $<
@@ -130,17 +237,43 @@ $(LIBJPEGTURBO): $(LIBJPEGTURBO_SRC)
 	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
 	@$(MAKE) CFLAGS+="\"-Drandom()=rand()\"" -C $(LIBJPEGTURBO_VERSION)
 
+$(LIBMAD): $(LIBMAD_SRC)
+	@[ -d $(LIBMAD_VERSION) ] || tar -xzf $<
+	@cd $(LIBMAD_VERSION) && \
+	 patch -Np1 -i ../libmad-0.15.1b.patch && \
+	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
+	@$(MAKE) -C $(LIBMAD_VERSION)
+
+$(LIBOGG): $(LIBOGG_SRC)
+	@[ -d $(LIBOGG_VERSION) ] || tar -xJf $<
+	@cd $(LIBOGG_VERSION) && \
+	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
+	@$(MAKE) -C $(LIBOGG_VERSION)
+
 $(LIBPNG): $(LIBPNG_SRC)
 	@[ -d $(LIBPNG_VERSION) ] || tar -xJf $<
 	@cd $(LIBPNG_VERSION) && \
 	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
 	@$(MAKE) -C $(LIBPNG_VERSION)
 
+$(LIBXML2): $(LIBXML2_SRC)
+	@[ -d $(LIBXML2_VERSION) ] || tar -xzf $<
+	@cd $(LIBXML2_VERSION) && \
+	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static --without-http --without-ftp --without-threads
+	@$(MAKE) -C $(LIBXML2_VERSION) libxml2.la
+
 $(LIBXMP_LITE): $(LIBXMP_LITE_SRC)
 	@[ -d $(LIBXMP_LITE_VERSION) ] || tar -xzf $<
 	@cd $(LIBXMP_LITE_VERSION) && \
 	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
 	@$(MAKE) -C $(LIBXMP_LITE_VERSION)
+
+$(MBED): $(MBED_SRC)
+	@[ -d $(MBED_VERSION) ] || tar xzf $<
+	@cd $(MBED_VERSION) && \
+	 patch -Np1 -i ../libmbedtls-2.2.1.patch && \
+	 cmake -DCMAKE_SYSTEM_NAME=Generic -DCMAKE_C_COMPILER=$(DEVKITARM)/bin/arm-none-eabi-gcc -DCMAKE_CXX_COMPILER=$(DEVKITARM)/bin/arm-none-eabi-g++ -DCMAKE_INSTALL_PREFIX=$(PORTLIBS_PATH)/armv6k -DCMAKE_C_FLAGS="$(CFLAGS)" -DCMAKE_CXX_FLAGS="$(CFLAGS) -fno-exceptions -fno-rtti" -DENABLE_ZLIB_SUPPORT=TRUE -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE .
+	@$(MAKE) -C $(MBED_VERSION)
 
 # sqlite won't work with -ffast-math
 $(SQLITE): $(SQLITE_SRC)
@@ -155,32 +288,62 @@ $(TINYXML): $(TINYXML_SRC)
 	@[ -d $(TINYXML_VERSION) ] || tar -xzf $<
 	@cd $(TINYXML_VERSION) && cmake -DCMAKE_SYSTEM_NAME=Generic -DCMAKE_C_COMPILER=$(DEVKITARM)/bin/arm-none-eabi-gcc -DCMAKE_CXX_COMPILER=$(DEVKITARM)/bin/arm-none-eabi-g++ -DCMAKE_INSTALL_PREFIX=$(PORTLIBS_PATH)/armv6k -DCMAKE_C_FLAGS="$(CFLAGS)" -DCMAKE_CXX_FLAGS="$(CFLAGS) -fno-exceptions -fno-rtti" . && make
 
+$(TREMOR): $(TREMOR_SRC)
+	@[ -d $(TREMOR_VERSION) ] || tar -xzf $<
+	@cd $(TREMOR_VERSION) && \
+	 ./autogen.sh --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --disable-oggtest
+	@$(MAKE) -C $(TREMOR_VERSION)
+
+$(XZ): $(XZ_SRC)
+	@[ -d $(XZ_VERSION) ] || tar -xJf $<
+	@cd $(XZ_VERSION) && \
+	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static --disable-xz --enable-threads=no
+	@$(MAKE) -C $(XZ_VERSION)
+
 $(ZLIB): $(ZLIB_SRC)
 	@[ -d $(ZLIB_VERSION) ] || tar -xzf $<
 	@cd $(ZLIB_VERSION) && \
 	 CHOST=arm-none-eabi ./configure --static --prefix=$(PORTLIBS_PATH)/armv6k
 	@$(MAKE) -C $(ZLIB_VERSION)
 
-install-zlib: 
+install-zlib:
 	@$(MAKE) -C $(ZLIB_VERSION) install
 
 install:
+	@[ ! -d $(BZIP2_VERSION) ] || $(MAKE) -C $(BZIP2_VERSION) PREFIX=$(PORTLIBS_PATH)/armv6k install
 	@[ ! -d $(FREETYPE_VERSION) ] || $(MAKE) -C $(FREETYPE_VERSION) install
+	@[ ! -d $(GIFLIB_VERSION) ] || $(MAKE) -C $(GIFLIB_VERSION) install
 	@[ ! -d $(JANSSON_VERSION) ] || $(MAKE) -C $(JANSSON_VERSION) install
+	@[ ! -d $(LIBCONFIG_VERSION) ] || $(MAKE) -C $(LIBCONFIG_VERSION)/lib install
 	@[ ! -d $(LIBEXIF_VERSION) ] || $(MAKE) -C $(LIBEXIF_VERSION) install
 	@[ ! -d $(LIBJPEGTURBO_VERSION) ] || $(MAKE) -C $(LIBJPEGTURBO_VERSION) install
+	@[ ! -d $(LIBMAD_VERSION) ] || $(MAKE) -C $(LIBMAD_VERSION) install
+	@[ ! -d $(LIBOGG_VERSION) ] || $(MAKE) -C $(LIBOGG_VERSION) install
 	@[ ! -d $(LIBPNG_VERSION) ] || $(MAKE) -C $(LIBPNG_VERSION) install
+	@[ ! -d $(LIBXML2_VERSION) ] || $(MAKE) -C $(LIBXML2_VERSION) install
 	@[ ! -d $(LIBXMP_LITE_VERSION) ] || $(MAKE) -C $(LIBXMP_LITE_VERSION) install
+	@[ ! -d $(MBED_VERSION) ] || $(MAKE) -C $(MBED_VERSION) install
 	@[ ! -d $(SQLITE_VERSION) ] || $(MAKE) -C $(SQLITE_VERSION) install-libLTLIBRARIES install-data
 	@[ ! -d $(TINYXML_VERSION) ] || $(MAKE) -C $(TINYXML_VERSION) install
+	@[ ! -d $(TREMOR_VERSION) ] || $(MAKE) -C $(TREMOR_VERSION) install
+	@[ ! -d $(XZ_VERSION) ] || $(MAKE) -C $(XZ_VERSION) install
 
 clean:
+	@$(RM) -r $(BZIP2_VERSION)
 	@$(RM) -r $(FREETYPE_VERSION)
+	@$(RM) -r $(GIFLIB_VERSION)
 	@$(RM) -r $(JANSSON_VERSION)
+	@$(RM) -r $(LIBCONFIG_VERSION)
 	@$(RM) -r $(LIBEXIF_VERSION)
 	@$(RM) -r $(LIBJPEGTURBO_VERSION)
+	@$(RM) -r $(LIBMAD_VERSION)
+	@$(RM) -r $(LIBOGG_VERSION)
 	@$(RM) -r $(LIBPNG_VERSION)
+	@$(RM) -r $(LIBXML2_VERSION)
 	@$(RM) -r $(LIBXMP_LITE_VERSION)
+	@$(RM) -r $(MBED_VERSION)
 	@$(RM) -r $(SQLITE_VERSION)
 	@$(RM) -r $(TINYXML_VERSION)
+	@$(RM) -r $(TREMOR_VERSION)
+	@$(RM) -r $(XZ_VERSION)
 	@$(RM) -r $(ZLIB_VERSION)

--- a/README.md
+++ b/README.md
@@ -15,24 +15,42 @@ install` in order for the portlibs to be installed.
 
 Currently supports the following portlibs:
 
+* bzip2
 * freetype (requires zlib)
+* giflib
 * jansson
+* libconfig
 * libexif
 * libjpeg-turbo
+* libmad
+* libogg
 * libpng (requires zlib)
+* libxml2
 * libxmp-lite
+* mbedtls (requires zlib) (without net component)
 * sqlite
 * tinyxml2
+* tremor (requires libogg)
+* xz
 * zlib
 
 Download links:
 
+* [bzip2-1.0.6] (http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz)
 * [freetype-2.6.2.tar.bz2] (http://download.savannah.gnu.org/releases/freetype/freetype-2.6.2.tar.bz2)
+* [giflib-5.1.1] (http://sourceforge.net/projects/giflib/files/giflib-5.1.1.tar.bz2)
 * [jansson-v2.7.tar.gz] (https://github.com/akheron/jansson/archive/v2.7.tar.gz)
+* [libconfig-1.5] (http://www.hyperrealm.com/libconfig/libconfig-1.5.tar.gz)
 * [libexif-0.6.21.tar.bz2] (http://sourceforge.net/projects/libexif/files/libexif/0.6.21/libexif-0.6.21.tar.bz2/download)
 * [libjpeg-turbo-1.4.2.tar.gz] (http://sourceforge.net/projects/libjpeg-turbo/files/1.4.2/libjpeg-turbo-1.4.2.tar.gz/download)
+* [libmad-0.15.1b] (http://sourceforge.net/projects/mad/files/libmad/0.15.1b/libmad-0.15.1b.tar.gz)
+* [libogg-1.3.2] (http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz)
 * [libpng-1.6.21.tar.xz] (http://prdownloads.sourceforge.net/libpng/libpng-1.6.21.tar.xz?download)
+* [libxml2-2.9.3] (http://xmlsoft.org/sources/libxml2-2.9.3.tar.gz)
 * [libxmp-lite-4.3.10.tar.gz](http://sourceforge.net/projects/xmp/files/libxmp/4.3.10/libxmp-lite-4.3.10.tar.gz/download)
+* [mbedtls-2.2.1] (https://tls.mbed.org/download/mbedtls-2.2.1-gpl.tgz)
 * [sqlite-autoconf-3100200.tar.gz] (https://www.sqlite.org/2016/sqlite-autoconf-3100200.tar.gz)
 * [tinyxml2-3.0.0.tar.gz] (https://github.com/leethomason/tinyxml2/archive/3.0.0.tar.gz)
+* [tremor-2a1a8f6] (https://git.xiph.org/?p=tremor.git;a=snapshot;h=2a1a8f621e500fdf0749f115e2206f82919560a3;sf=tgz)
+* [xz-5.2.2] (http://tukaani.org/xz/xz-5.2.2.tar.xz)
 * [zlib-1.2.8.tar.gz] (http://prdownloads.sourceforge.net/libpng/zlib-1.2.8.tar.gz?download)

--- a/libmad-0.15.1b.patch
+++ b/libmad-0.15.1b.patch
@@ -1,0 +1,91 @@
+Submitted By:            Igor Živković <contact at igor hyphen zivkovic dot from dot hr>
+Date:                    2013-07-04
+Initial Package Version: 0.15.1b
+Upstream Status:         Reported
+Origin:                  Arch Linux packages repository
+Description:             Fixes compilation on x86-64 and optimization issues.
+
+diff -Naur libmad-0.15.1b.orig/configure.ac libmad-0.15.1b/configure.ac
+--- libmad-0.15.1b.orig/configure.ac	2004-01-23 10:41:32.000000000 +0100
++++ libmad-0.15.1b/configure.ac	2013-07-04 15:55:09.323764417 +0200
+@@ -124,71 +124,7 @@
+ 
+ if test "$GCC" = yes
+ then
+-    if test -z "$arch"
+-    then
+-	case "$host" in
+-	    i386-*)           ;;
+-	    i?86-*)           arch="-march=i486" ;;
+-	    arm*-empeg-*)     arch="-march=armv4 -mtune=strongarm1100" ;;
+-	    armv4*-*)         arch="-march=armv4 -mtune=strongarm" ;;
+-	    powerpc-*)        ;;
+-	    mips*-agenda-*)   arch="-mcpu=vr4100" ;;
+-	    mips*-luxsonor-*) arch="-mips1 -mcpu=r3000 -Wa,-m4010" ;;
+-	esac
+-    fi
+-
+-    case "$optimize" in
+-	-O|"-O "*)
+-	    optimize="-O"
+-	    optimize="$optimize -fforce-mem"
+-	    optimize="$optimize -fforce-addr"
+-	    : #x optimize="$optimize -finline-functions"
+-	    : #- optimize="$optimize -fstrength-reduce"
+-	    optimize="$optimize -fthread-jumps"
+-	    optimize="$optimize -fcse-follow-jumps"
+-	    optimize="$optimize -fcse-skip-blocks"
+-	    : #x optimize="$optimize -frerun-cse-after-loop"
+-	    : #x optimize="$optimize -frerun-loop-opt"
+-	    : #x optimize="$optimize -fgcse"
+-	    optimize="$optimize -fexpensive-optimizations"
+-	    optimize="$optimize -fregmove"
+-	    : #* optimize="$optimize -fdelayed-branch"
+-	    : #x optimize="$optimize -fschedule-insns"
+-	    optimize="$optimize -fschedule-insns2"
+-	    : #? optimize="$optimize -ffunction-sections"
+-	    : #? optimize="$optimize -fcaller-saves"
+-	    : #> optimize="$optimize -funroll-loops"
+-	    : #> optimize="$optimize -funroll-all-loops"
+-	    : #x optimize="$optimize -fmove-all-movables"
+-	    : #x optimize="$optimize -freduce-all-givs"
+-	    : #? optimize="$optimize -fstrict-aliasing"
+-	    : #* optimize="$optimize -fstructure-noalias"
+-
+-	    case "$host" in
+-		arm*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		mips*-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    optimize="$optimize -finline-functions"
+-		    ;;
+-		i?86-*)
+-		    optimize="$optimize -fstrength-reduce"
+-		    ;;
+-		powerpc-apple-*)
+-		    # this triggers an internal compiler error with gcc2
+-		    : #optimize="$optimize -fstrength-reduce"
+-
+-		    # this is really only beneficial with gcc3
+-		    : #optimize="$optimize -finline-functions"
+-		    ;;
+-		*)
+-		    # this sometimes provokes bugs in gcc 2.95.2
+-		    : #optimize="$optimize -fstrength-reduce"
+-		    ;;
+-	    esac
+-	    ;;
+-    esac
++    optimize="-O2"
+ fi
+ 
+ case "$host" in
+@@ -297,6 +233,7 @@
+ then
+     case "$host" in
+ 	i?86-*)     FPM="INTEL"  ;;
++	x86_64*)    FPM="64BIT"  ;;
+ 	arm*-*)     FPM="ARM"    ;;
+ 	mips*-*)    FPM="MIPS"   ;;
+ 	sparc*-*)   FPM="SPARC"  ;;

--- a/libmbedtls-2.2.1.patch
+++ b/libmbedtls-2.2.1.patch
@@ -1,0 +1,12 @@
+diff -Naur mbedtls-2.2.1/include/mbedtls/config.h mbedtls-2.2.1-mod/include/mbedtls/config.h
+--- mbedtls-2.2.1/include/mbedtls/config.h	2016-01-04 20:38:18.000000000 -0800
++++ mbedtls-2.2.1-mod/include/mbedtls/config.h	2016-05-21 11:43:29.887604004 -0700
+@@ -1905,7 +1905,7 @@
+  *
+  * This module provides TCP/IP networking routines.
+  */
+-#define MBEDTLS_NET_C
++//#define MBEDTLS_NET_C
+ 
+ /**
+  * \def MBEDTLS_OID_C


### PR DESCRIPTION
This includes all the libraries that are in cpp3ds's fork of 3ds_portlibs (except for two, OpenAL and PhysFS because of build errors), as well as MbedTLS, in a PR to 3ds_portlibs (cpp3ds/3ds_portlibs#3).

Due to errors in net.c of MbedTLS, I disabled it in the config.h. More work can go into that later, presumably.
