### PR TITLE
Adding libssh2 to portlibs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ LIBPNG_VERSION        := $(LIBPNG)-1.6.21
 LIBPNG_SRC            := $(LIBPNG_VERSION).tar.xz
 LIBPNG_DOWNLOAD       := http://prdownloads.sourceforge.net/libpng/libpng-1.6.21.tar.xz?download
 
+LIBSSH2                := libssh2
+LIBSSH2_VERSION        := $(LIBSSH2)-1.8.0
+LIBSSH2_SRC            := $(LIBSSH2_VERSION).tar.xz
+LIBSSH2_DOWNLOAD       := https://www.libssh2.org/download/libssh2-1.8.0.tar.gz
+
 LIBXML2               := libxml2
 LIBXML2_VERSION       := $(LIBXML2)-2.9.3
 LIBXML2_SRC           := $(LIBXML2_VERSION).tar.gz
@@ -108,6 +113,7 @@ export LDFLAGS        := -L$(PORTLIBS_PATH)/armv6k/lib
         $(LIBOGG) \
         $(LIBPNG) \
         $(MBED) \
+        $(LIBSSH2) \
         $(LIBXML2) \
         $(LIBXMP_LITE) \
         $(SQLITE) \
@@ -130,6 +136,7 @@ all:
 	@echo "  $(LIBPNG) (requires zlib to be installed)"
 	@echo "  $(LIBXML2)"
 	@echo "  $(LIBXMP_LITE)"
+	@echo "  $(LIBSSH2) (required mbedtls, better with zlib installed)"
 	@echo "  $(MBED) (requires zlib to be installed)"
 	@echo "  $(SQLITE)"
 	@echo "  $(TINYXML)"
@@ -137,7 +144,7 @@ all:
 	@echo "  $(XZ)"
 	@echo "  $(ZLIB)"
 
-download: $(BZIP2_SRC) $(FREETYPE_SRC) $(GIFLIB_SRC) $(JANSSON_SRC) $(LIBCONFIG_SRC) $(LIBEXIF_SRC) $(LIBJPEGTURBO_SRC) $(LIBMAD_SRC) $(LIBOGG_SRC) $(LIBPNG_SRC) $(LIBXML2_SRC) $(LIBXMP_LITE_SRC) $(MBED_SRC) $(SQLITE_SRC) $(TINYXML_SRC) $(TREMOR_SRC) $(XZ_SRC) $(ZLIB_SRC)
+download: $(BZIP2_SRC) $(FREETYPE_SRC) $(GIFLIB_SRC) $(JANSSON_SRC) $(LIBCONFIG_SRC) $(LIBEXIF_SRC) $(LIBJPEGTURBO_SRC) $(LIBMAD_SRC) $(LIBOGG_SRC) $(LIBPNG_SRC) $(LIBSSH2_SRC) $(LIBXML2_SRC) $(LIBXMP_LITE_SRC) $(MBED_SRC) $(SQLITE_SRC) $(TINYXML_SRC) $(TREMOR_SRC) $(XZ_SRC) $(ZLIB_SRC)
 
 DOWNLOAD = wget -O "$(1)" "$(2)" || curl -Lo "$(1)" "$(2)"
 
@@ -170,6 +177,9 @@ $(LIBOGG_SRC):
 
 $(LIBPNG_SRC):
 	@$(call DOWNLOAD,$@,$(LIBPNG_DOWNLOAD))
+
+$(LIBSSH2_SRC):
+	@$(call DOWNLOAD,$@,$(LIBSSH2_DOWNLOAD))
 
 $(LIBXML2_SRC):
 	@$(call DOWNLOAD,$@,$(LIBXML2_DOWNLOAD))
@@ -256,6 +266,14 @@ $(LIBPNG): $(LIBPNG_SRC)
 	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static
 	@$(MAKE) -C $(LIBPNG_VERSION)
 
+#LDLIBS="-llibctru"
+$(LIBSSH2): $(LIBSSH2_SRC)
+	@[ -d $(LIBSSH2_VERSION) ] || tar -xJf $<
+	@cd $(LIBSSH2_VERSION) && \
+	 patch -Np1 -i ../libssh2-1.8.0.patch && \
+	 ./configure --prefix=$(PORTLIBS_PATH)/armv6k --host=arm-none-eabi --disable-shared --enable-static --with-mbedtls=$(PORTLIBS_PATH)/armv6k --with-libmbedtls-prefix=$(PORTLIBS_PATH)/armv6k --disable-examples-build
+	@$(MAKE) -C $(LIBSSH2_VERSION)
+
 $(LIBXML2): $(LIBXML2_SRC)
 	@[ -d $(LIBXML2_VERSION) ] || tar -xzf $<
 	@cd $(LIBXML2_VERSION) && \
@@ -330,6 +348,7 @@ install:
 	@[ ! -d $(LIBMAD_VERSION) ] || $(MAKE) -C $(LIBMAD_VERSION) install
 	@[ ! -d $(LIBOGG_VERSION) ] || $(MAKE) -C $(LIBOGG_VERSION) install
 	@[ ! -d $(LIBPNG_VERSION) ] || $(MAKE) -C $(LIBPNG_VERSION) install
+	@[ ! -d $(LIBSSH2_VERSION) ] || $(MAKE) -C $(LIBSSH2_VERSION) install
 	@[ ! -d $(LIBXML2_VERSION) ] || $(MAKE) -C $(LIBXML2_VERSION) install
 	@[ ! -d $(LIBXMP_LITE_VERSION) ] || $(MAKE) -C $(LIBXMP_LITE_VERSION) install
 	@[ ! -d $(MBED_VERSION) ] || $(MAKE) -C $(MBED_VERSION) install
@@ -349,6 +368,7 @@ clean:
 	@$(RM) -r $(LIBMAD_VERSION)
 	@$(RM) -r $(LIBOGG_VERSION)
 	@$(RM) -r $(LIBPNG_VERSION)
+	@$(RM) -r $(LIBSSH2_VERSION)
 	@$(RM) -r $(LIBXML2_VERSION)
 	@$(RM) -r $(LIBXMP_LITE_VERSION)
 	@$(RM) -r $(MBED_VERSION)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently supports the following portlibs:
 * libmad
 * libogg
 * libpng (requires zlib)
+* libssh2 (requires mbedtls, better with zlib)
 * libxml2
 * libxmp-lite
 * mbedtls (requires zlib) (without net component)
@@ -46,6 +47,7 @@ Download links:
 * [libmad-0.15.1b] (http://sourceforge.net/projects/mad/files/libmad/0.15.1b/libmad-0.15.1b.tar.gz)
 * [libogg-1.3.2] (http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz)
 * [libpng-1.6.21.tar.xz] (http://prdownloads.sourceforge.net/libpng/libpng-1.6.21.tar.xz?download)
+* [libssh2-1.8.0] (https://www.libssh2.org/download/libssh2-1.8.0.tar.gz)
 * [libxml2-2.9.3] (http://xmlsoft.org/sources/libxml2-2.9.3.tar.gz)
 * [libxmp-lite-4.3.10.tar.gz](http://sourceforge.net/projects/xmp/files/libxmp/4.3.10/libxmp-lite-4.3.10.tar.gz/download)
 * [mbedtls-2.2.1] (https://tls.mbed.org/download/mbedtls-2.2.1-gpl.tgz)

--- a/libssh2-1.8.0.patch
+++ b/libssh2-1.8.0.patch
@@ -1,0 +1,49 @@
+diff -Naur libssh2-1.8.0/Makefile.am.orig libssh2-1.8.0/Makefile.am
+--- libssh2-1.8.0/Makefile.am	2016-12-02 20:07:34.000000000 -0500
++++ libssh2-1.8.0-mod/Makefile.am	2016-12-02 20:07:48.000000000 -0500
+@@ -1,6 +1,6 @@
+ AUTOMAKE_OPTIONS = foreign nostdinc
+ 
+-SUBDIRS = src tests docs
++SUBDIRS = src docs
+ if BUILD_EXAMPLES
+ SUBDIRS += example
+ endif
+
+diff -Naur libssh2-1.8.0/src/libssh2_priv.h.orig libssh2-1.8.0/src/libssh2_priv.h
+--- libssh2-1.8.0/src/libssh2_priv.h	2016-12-02 20:11:49.000000000 -0500
++++ libssh2-1.8.0-mod/src/libssh2_priv.h	2016-12-02 20:12:17.000000000 -0500
+@@ -132,6 +132,11 @@
+ 
+ #endif /* WIN32 */
+ 
++struct iovec {
++    size_t iov_len;
++    void * iov_base;
++};
++
+ #ifdef __OS400__
+ /* Force parameter type. */
+ #define send(s, b, l, f)    send((s), (unsigned char *) (b), (l), (f))
+
+diff -Naur libssh2-1.8.0/Makefile.in libssh2-1.8.0-mod/Makefile.in
+--- libssh2-1.8.0/Makefile.in	2016-10-25 02:44:33.000000000 -0400
++++ libssh2-1.8.0-mod/Makefile.in	2016-12-02 20:19:50.000000000 -0500
+@@ -195,7 +195,7 @@
+ ETAGS = etags
+ CTAGS = ctags
+ CSCOPE = cscope
+-DIST_SUBDIRS = src tests docs example
++DIST_SUBDIRS = src docs
+ am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.inc \
+ 	$(srcdir)/libssh2.pc.in COPYING ChangeLog NEWS README compile \
+ 	config.guess config.rpath config.sub depcomp install-sh \
+@@ -389,7 +389,7 @@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = foreign nostdinc
+-SUBDIRS = src tests docs $(am__append_1)
++SUBDIRS = src docs $(am__append_1)
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libssh2.pc
+ include_HEADERS = \


### PR DESCRIPTION
Secure two-way communication opens up lots of homebrew possibilities.
Depends on working mbedtls (see my other PR).